### PR TITLE
Fix broken link to Avellaneda-Stoikov post

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Welcome to My Blog. -->
             - [2024 - Causal Generative Modeling - a short intro](./_posts/2024-12-23-Causal Generative Modeling.md)
 
 - FinTech
-    - [2025 - High Frequency Trading - 1](./_posts/2025-09-13-2025-09-13-Market making with Avellaneda and Stoikov.md)
+    - [2025 - High Frequency Trading - 1](./_posts/2025-09-13-Market%20making%20with%20Avellaneda%20and%20Stoikov.md)
 
 ### Older posts:
 


### PR DESCRIPTION
## Summary
- correct hyperlink for *High Frequency Trading - 1* post so it links to the existing Avellaneda-Stoikov article

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f3400d20832497add5c50ec0d110